### PR TITLE
Add a local character infos property to the render game module

### DIFF
--- a/game/api-render-game/src/lib.rs
+++ b/game/api-render-game/src/lib.rs
@@ -90,7 +90,7 @@ impl RenderGameInterface for ApiRenderGame {
     }
 
     #[guest_func_call_from_host_auto(option)]
-    fn continue_map_loading(&mut self) -> Result<bool, String> {}
+    fn continue_loading(&mut self) -> Result<bool, String> {}
 
     #[guest_func_call_from_host_auto(option)]
     fn set_chat_commands(&mut self, chat_commands: ChatCommands) {}

--- a/game/client-containers/src/container.rs
+++ b/game/client-containers/src/container.rs
@@ -1065,6 +1065,26 @@ where
         }
     }
 
+    /// Returns `true` if the resource was loaded or failed to load (and will not be loaded),
+    /// `false` otherwise.
+    ///
+    /// This call is non-blocking.
+    pub fn is_loaded_or_failed<Q>(&mut self, name: &Q) -> bool
+    where
+        Q: Borrow<ContainerKey>,
+    {
+        self.failed_tasks.contains(name.borrow()) || {
+            let item_res = self.items.get(name.borrow());
+            if item_res.is_none() {
+                // try to load the resource
+                self.get_or_default(name);
+                false
+            } else {
+                true
+            }
+        }
+    }
+
     /// Blocking wait for the item to be finished.
     ///
     /// This is only useful for programs that don't run

--- a/game/client-demo/src/lib.rs
+++ b/game/client-demo/src/lib.rs
@@ -31,6 +31,7 @@ use demo::{
     ChunkHeader, DemoEvent, DemoEvents, DemoHeader, DemoHeaderExt, DemoSnapshot, DemoTail,
 };
 use egui::{FontDefinitions, Rect};
+use game_base::{assets_url::HTTP_RESOURCE_URL, game_types::intra_tick_time_to_ratio};
 use game_config::config::{ConfigGame, ConfigMap, ConfigRender, ConfigSoundRender};
 use game_interface::{interface::GameStateInterface, types::game::GameTickType};
 use graphics::{
@@ -50,7 +51,6 @@ use pool::datatypes::{
 };
 use pool::mt_datatypes::PoolCow as MtPoolCow;
 use serde::de::DeserializeOwned;
-use game_base::{assets_url::HTTP_RESOURCE_URL, game_types::intra_tick_time_to_ratio};
 use sound::{
     commands::{SceneAirMode, SoundSceneCreateProps},
     sound::SoundManager,
@@ -787,6 +787,7 @@ impl DemoViewerImpl {
                                 map_hash: ext.map_hash,
                                 game_options: ext.game_options.clone(),
                                 required_resources: ext.required_resources.clone(),
+                                client_local_infos: ext.client_local_infos.clone(),
                                 physics_module: ext.physics_mod.clone(),
                                 render_module: ext.render_mod.clone(),
                                 physics_group_name: ext.physics_group_name.clone(),
@@ -1201,6 +1202,10 @@ impl DemoViewer {
                                 required_resources: demo_container
                                     .header_ext
                                     .required_resources
+                                    .clone(),
+                                client_local_infos: demo_container
+                                    .header_ext
+                                    .client_local_infos
                                     .clone(),
                             },
                         )

--- a/game/client-map/src/client_map.rs
+++ b/game/client-map/src/client_map.rs
@@ -631,7 +631,7 @@ impl ClientMapLoading {
                                 }
                             }
                             GameLoading::Game(mut load_game) => {
-                                match load_game.continue_map_loading() {
+                                match load_game.continue_loading() {
                                     Ok(loaded) => {
                                         if loaded {
                                             match (

--- a/game/demo/src/lib.rs
+++ b/game/demo/src/lib.rs
@@ -11,16 +11,19 @@ use base::{
     hash::Hash,
     network_string::{NetworkReducedAsciiString, NetworkString},
 };
+use game_base::{
+    network::{
+        messages::{GameModification, RenderModification, RequiredResources},
+        types::chat::NetChatMsg,
+    },
+    types::ClientLocalInfos,
+};
 use game_interface::{
     events::GameEvents,
     interface::{GameStateCreateOptions, MAX_MAP_NAME_LEN, MAX_PHYSICS_GROUP_NAME_LEN},
     types::game::NonZeroGameTickType,
 };
 use serde::{Deserialize, Serialize};
-use game_base::network::{
-    messages::{GameModification, RenderModification, RequiredResources},
-    types::chat::NetChatMsg,
-};
 
 pub type DemoGameModification = GameModification;
 pub type DemoRenderModification = RenderModification;
@@ -61,6 +64,9 @@ pub struct DemoHeaderExt {
     /// the game/demo starts (e.g. because the game mod requires
     /// them for gameplay).
     pub required_resources: RequiredResources,
+    /// Resources the client most likely sees first
+    /// (e.g. as part of local player information).
+    pub client_local_infos: ClientLocalInfos,
     pub map: NetworkReducedAsciiString<MAX_MAP_NAME_LEN>,
     pub map_hash: Hash,
     pub ticks_per_second: NonZeroGameTickType,

--- a/game/demo/src/recorder.rs
+++ b/game/demo/src/recorder.rs
@@ -11,13 +11,13 @@ use std::{
 use anyhow::anyhow;
 use base::{hash::Hash, network_string::NetworkReducedAsciiString};
 use base_io::io::Io;
+use game_base::{network::messages::RequiredResources, types::ClientLocalInfos};
 use game_interface::{
     interface::{GameStateCreateOptions, MAX_MAP_NAME_LEN, MAX_PHYSICS_GROUP_NAME_LEN},
     types::game::NonZeroGameTickType,
 };
 use itertools::Itertools;
 use serde::Serialize;
-use game_base::network::messages::RequiredResources;
 
 use crate::{
     ChunkHeader, DemoEvent, DemoEvents, DemoGameModification, DemoHeader, DemoHeaderExt,
@@ -38,6 +38,7 @@ pub struct DemoRecorderCreatePropsBase {
     pub map_hash: Hash,
     pub game_options: GameStateCreateOptions,
     pub required_resources: RequiredResources,
+    pub client_local_infos: ClientLocalInfos,
     pub physics_module: DemoGameModification,
     pub render_module: DemoRenderModification,
     pub physics_group_name: NetworkReducedAsciiString<MAX_PHYSICS_GROUP_NAME_LEN>,
@@ -95,6 +96,7 @@ impl DemoRecorder {
             physics_mod: base.physics_module,
             render_mod: base.render_module,
             required_resources: base.required_resources,
+            client_local_infos: base.client_local_infos,
             map: base.map,
             map_hash: base.map_hash,
             ticks_per_second,

--- a/game/game-base/src/types.rs
+++ b/game/game-base/src/types.rs
@@ -1,1 +1,3 @@
-pub type ClientID = i64;
+use game_interface::types::character_info::NetworkCharacterInfo;
+
+pub type ClientLocalInfos = Vec<NetworkCharacterInfo>;

--- a/game/game-server/src/server.rs
+++ b/game/game-server/src/server.rs
@@ -1859,7 +1859,8 @@ impl Server {
                                 account_db: None,
                                 config: self.game_server.game.info.config.clone(),
                             },
-                            required_resources: Default::default(), /* TODO: */
+                            required_resources: self.game_server.required_resources.clone(),
+                            client_local_infos: Default::default(),
                             physics_module: self.game_server.game_mod.clone(),
                             render_module: self.game_server.render_mod.clone(),
                             physics_group_name: self

--- a/game/render-game-wasm/src/render/render_wasm.rs
+++ b/game/render-game-wasm/src/render/render_wasm.rs
@@ -98,7 +98,7 @@ pub mod render_wasm {
         }
 
         #[wasm_func_auto_call]
-        fn continue_map_loading(&mut self) -> Result<bool, String> {}
+        fn continue_loading(&mut self) -> Result<bool, String> {}
 
         #[wasm_func_auto_call]
         fn set_chat_commands(&mut self, chat_commands: ChatCommands) {}

--- a/game/render-game-wasm/src/render/render_wasm_manager.rs
+++ b/game/render-game-wasm/src/render/render_wasm_manager.rs
@@ -143,8 +143,8 @@ impl RenderGameInterface for RenderGameWasmManager {
         self.state.as_mut().render(config_map, cur_time, input)
     }
 
-    fn continue_map_loading(&mut self) -> Result<bool, String> {
-        self.state.as_mut().continue_map_loading()
+    fn continue_loading(&mut self) -> Result<bool, String> {
+        self.state.as_mut().continue_loading()
     }
 
     fn set_chat_commands(&mut self, chat_commands: ChatCommands) {

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -2377,6 +2377,7 @@ impl FromNativeLoadingImpl<ClientNativeLoadingImpl> for ClientNativeImpl {
                 sound_props: Default::default(),
                 render_mod: RenderModTy::Native,
                 required_resources: Default::default(),
+                client_local_infos: Default::default(),
             },
         );
         benchmark.bench("menu map");


### PR DESCRIPTION
Which allows the render module to load the skins and assets from local players quicker.
Additionally rename the continue_map_loading to continue_loading, and make the local skins & particles a requirement. (For spawning)