### PR TITLE
Don't scale nameplates with ingame ui.

### DIFF
--- a/game/client-console/src/console/console.rs
+++ b/game/client-console/src/console/console.rs
@@ -103,6 +103,8 @@ impl<E, T> ConsoleRender<E, T> {
         pipe: &mut ConsoleRenderPipe,
         can_change_client_config: bool,
     ) -> egui::PlatformOutput {
+        self.ui.load_monospace_fonts();
+
         let mut user_data = UserData {
             entries: &self.entries,
             msgs: pipe.msgs,

--- a/game/client-render-game/src/render_game.rs
+++ b/game/client-render-game/src/render_game.rs
@@ -479,15 +479,19 @@ impl RenderGame {
             &scene,
         );
 
+        // Use own ui context for nameplates
+        let mut nameplats_creator = UiCreator::default();
+        nameplats_creator.load_font(&props.fonts);
+
+        let players = Players::new(graphics, &nameplats_creator);
+        let render = GameObjectsRender::new(graphics);
+        let cursor_render = RenderCursor::new(graphics);
+        let particles = ParticleManager::new(graphics, cur_time);
+
         let mut creator = UiCreator::default();
         creator.load_font(&props.fonts);
 
-        let players = Players::new(graphics, &creator);
-        let render = GameObjectsRender::new(graphics);
-        let cursor_render = RenderCursor::new(graphics);
         let hud = RenderHud::new(graphics, &creator);
-        let particles = ParticleManager::new(graphics, cur_time);
-
         let chat = ChatRender::new(graphics, &creator);
         let actionfeed = ActionfeedRender::new(graphics, &creator);
         let scoreboard = ScoreboardRender::new(graphics, &creator);

--- a/game/client-render/src/nameplates/render.rs
+++ b/game/client-render/src/nameplates/render.rs
@@ -80,7 +80,7 @@ impl NameplateRender {
                     let size = ui.ctx().screen_rect().size();
                     let (x0, y0, x1, y1) = pipe.state.get_canvas_mapping();
 
-                    let name_scale = size.x / self.canvas_handle.canvas_width();
+                    let name_scale = self.canvas_handle.canvas_width() / size.x;
 
                     let w = x1 - x0;
                     let h = y1 - y0;


### PR DESCRIPTION
Reduce memory consumption by not loading monospace fonts by default anymore