### PR TITLE
Allow to specify a path for the server provided assets.

### DIFF
--- a/game/game-config/src/config.rs
+++ b/game/game-config/src/config.rs
@@ -671,6 +671,13 @@ pub struct ConfigServer {
     /// Path to the map votes file.
     #[default = "map_votes.json"]
     pub map_votes_path: String,
+    /// Path to the server provided asset files.
+    /// The dictionary structure should match the one from
+    /// the data directory.
+    /// Assets include the hash in the file name.
+    /// An empty string disables server provided assets.
+    #[default = ""]
+    pub provided_assets_path: String,
     /// Whether to allow spatial chat on this server.
     /// Note that spatial chat causes lot of network
     /// traffic.

--- a/game/game-server/src/server.rs
+++ b/game/game-server/src/server.rs
@@ -926,6 +926,11 @@ impl Server {
                 config_game.sv.spatial_chat,
                 config_game.sv.download_server_port_v4,
                 config_game.sv.download_server_port_v6,
+                if !config_game.sv.provided_assets_path.is_empty() {
+                    Some(config_game.sv.provided_assets_path.as_ref())
+                } else {
+                    None
+                },
             )?,
 
             last_tick_time: sys.time_get(),
@@ -3546,6 +3551,11 @@ impl Server {
             self.config_game.sv.spatial_chat,
             self.config_game.sv.download_server_port_v4,
             self.config_game.sv.download_server_port_v6,
+            if !self.config_game.sv.provided_assets_path.is_empty() {
+                Some(self.config_game.sv.provided_assets_path.as_ref())
+            } else {
+                None
+            },
         )?;
         if let Some(snapshot) = snapshot {
             self.game_server

--- a/game/vanilla/src/state.rs
+++ b/game/vanilla/src/state.rs
@@ -1575,7 +1575,7 @@ pub mod state {
             }
         }
 
-        fn chech_player_info(
+        fn check_player_info(
             &self,
             mut info: NetworkCharacterInfo,
             player_id: Option<PlayerId>,
@@ -2069,7 +2069,7 @@ pub mod state {
             let player_id = self.id_generator.next_id();
             let stage_0_id = self.stage_0_id;
 
-            let character_info = self.chech_player_info(client_player_info.info.clone(), None);
+            let character_info = self.check_player_info(client_player_info.info.clone(), None);
 
             self.game
                 .stages
@@ -2223,7 +2223,7 @@ pub mod state {
             version: NonZeroU64,
         ) {
             let old_info = &mut None;
-            let new_info = self.chech_player_info(info.clone(), Some(*id));
+            let new_info = self.check_player_info(info.clone(), Some(*id));
             let mut stage_id = self.stage_0_id;
             if let Some(player) = self.game.players.player(id) {
                 stage_id = player.stage_id();

--- a/lib/base/src/network_string.rs
+++ b/lib/base/src/network_string.rs
@@ -125,7 +125,7 @@ pub enum NetworkAsciiStringError {
     #[error("The ascii string length exceeded the allowed maximum length of {0}")]
     InvalidLength(usize),
     #[error("{0}")]
-    RedcuedAsciiStrErr(ReducedAsciiStringError),
+    ReducedAsciiStrErr(ReducedAsciiStringError),
 }
 
 /// A string that is purely ascii and additionally is limited to the following
@@ -146,7 +146,7 @@ impl<const MAX_LENGTH: usize> NetworkReducedAsciiString<MAX_LENGTH> {
         if s.chars().count() > MAX_LENGTH {
             Err(NetworkAsciiStringError::InvalidLength(MAX_LENGTH))
         } else {
-            ReducedAsciiString::is_valid(s).map_err(NetworkAsciiStringError::RedcuedAsciiStrErr)?;
+            ReducedAsciiString::is_valid(s).map_err(NetworkAsciiStringError::ReducedAsciiStrErr)?;
             Ok(())
         }
     }
@@ -154,11 +154,10 @@ impl<const MAX_LENGTH: usize> NetworkReducedAsciiString<MAX_LENGTH> {
     pub fn new(
         s: impl TryInto<ReducedAsciiString, Error = ReducedAsciiStringError>,
     ) -> Result<Self, NetworkAsciiStringError> {
-        let s = s
+        let s: ReducedAsciiString = s
             .try_into()
-            .map_err(NetworkAsciiStringError::RedcuedAsciiStrErr)?;
-        Self::is_valid(&s)?;
-        Ok(Self(s))
+            .map_err(NetworkAsciiStringError::ReducedAsciiStrErr)?;
+        Self::try_from(s)
     }
 
     pub fn from_str_lossy(s: &str) -> Self {
@@ -183,7 +182,7 @@ impl<'de, const MAX_LENGTH: usize> de::Deserialize<'de> for NetworkReducedAsciiS
                         inner.chars().count(),
                         &format!("a char length lower than the maximum: {len}").as_str(),
                     ),
-                    NetworkAsciiStringError::RedcuedAsciiStrErr(ReducedAsciiStringError::InvalidCharacter(char)) => de::Error::invalid_value(
+                    NetworkAsciiStringError::ReducedAsciiStrErr(ReducedAsciiStringError::InvalidCharacter(char)) => de::Error::invalid_value(
                         de::Unexpected::Char(char),
                         &"expected a pure ascii string with reduced character set ([A-Z,a-z,0-9] & \"_ \")",
                     ),
@@ -204,6 +203,16 @@ impl<const MAX_LENGTH: usize> TryFrom<&str> for NetworkReducedAsciiString<MAX_LE
 impl<const MAX_LENGTH: usize> From<NetworkReducedAsciiString<MAX_LENGTH>> for ReducedAsciiString {
     fn from(value: NetworkReducedAsciiString<MAX_LENGTH>) -> Self {
         value.0
+    }
+}
+
+impl<const MAX_LENGTH: usize> TryFrom<ReducedAsciiString>
+    for NetworkReducedAsciiString<MAX_LENGTH>
+{
+    type Error = NetworkAsciiStringError;
+    fn try_from(value: ReducedAsciiString) -> Result<Self, Self::Error> {
+        Self::is_valid(&value)?;
+        Ok(Self(value))
     }
 }
 


### PR DESCRIPTION
For now in config dir only:

Allows mods to specify an asset, like skin, with a name + hash to force the client to load exactly that asset (triggering the download from game server instead of the assets server).
```rs
// info here is the player info, like name, skin etc.
info.skin = ResourceKeyBase {
    name: "default".try_into().unwrap(),
    hash: decode_hash(
        "eca1544ddc97c33db47e2543ae0ff42b7f6909860dc8dad039887101dbc72d09",
    ),
}
.try_into()
.unwrap();
```