### PR TITLE
fix parallax for foreground layers in the editor

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,3 +18,6 @@ rustflags = [
 rustflags = [
     "-C", "target-feature=+simd128"
 ]
+
+[net]
+git-fetch-with-cli = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12584,3 +12584,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "ffmpeg-sys-next"
+version = "7.1.0"
+source = "git+https://github.com/Jupeyy/rust-ffmpeg-sys.git?branch=pr_mingw_workaround#554c0a709cf93471f03ada8939fe979b9d757300"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,8 +3869,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "7.1.0"
-source = "git+https://github.com/Jupeyy/rust-ffmpeg-sys.git?branch=pr_mingw_workaround#554c0a709cf93471f03ada8939fe979b9d757300"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
 dependencies = [
  "bindgen",
  "cc",

--- a/game/map/src/map/groups.rs
+++ b/game/map/src/map/groups.rs
@@ -6,7 +6,7 @@ use anyhow::anyhow;
 use assets_base::tar::tar_entry_to_file;
 use base::join_all;
 use hiarc::Hiarc;
-use math::math::vector::{fvec2, ufvec2};
+use math::math::vector::{ffixed, fvec2, ufvec2};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -23,12 +23,22 @@ pub struct MapGroupAttrClipping {
     pub size: ufvec2,
 }
 
-#[derive(Debug, Hiarc, Clone, Default, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Hiarc, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MapGroupAttr {
     pub offset: fvec2,
     pub parallax: fvec2,
 
     pub clipping: Option<MapGroupAttrClipping>,
+}
+
+impl Default for MapGroupAttr {
+    fn default() -> Self {
+        Self {
+            offset: Default::default(),
+            parallax: fvec2::new(ffixed::from_num(100.0), ffixed::from_num(100.0)),
+            clipping: None,
+        }
+    }
 }
 
 #[derive(Debug, Hiarc, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
fix parallax being set to 0 by default within foreground layers.

also adds
```
[net]
git-fetch-with-cli = true
```
because cratepatches dont work without when using ssh auth.
no idea why the build on windows fails for this, is that an upstream issue of `ffmpeg-sys-next`?