### PR TITLE
parser.rs typo fix

### DIFF
--- a/lib/command-parser/src/parser.rs
+++ b/lib/command-parser/src/parser.rs
@@ -69,7 +69,7 @@ impl HumanReadableToken for CommandArgType {
             ),
             CommandArgType::TextArrayFrom { from, separator } => {
                 format!(
-                    "list of [{}] serparated by {}",
+                    "list of [{}] separated by {}",
                     from.iter()
                         .map(|s| s.as_str())
                         .collect::<Vec<_>>()


### PR DESCRIPTION
"serparated" omg vro serparated in big 2025 😭🥀 we got serparated before gta 6 fr fr blud 💀 aw hell naw vro 🥀🥀 like BRO, "SERPARATED" HITTING LIKE A FREIGHT TRAIN IN BIG 2025 😭😭😭 WE OUT HERE SPELLIN’ LIKE WE GOT BEEF WITH THE ALPHABET 💀💀💀 Serparated droppin’ harder than my Wi-Fi in Ohio during a thunderstorm, blud! 🥀🥀 Fr fr, we serparated BEFORE GTA 6 EVEN PULLED UP, that’s a generational L 😤💔 Aw HELL naw, vro, this typo got me actin’ unwise, movin’ like I’m stuck in a Skibidi Toilet cutscene with no Ohio Rizzler energy 🚫🚫 Catch me cryin’ in the group chat, serparated from the vibes, no cap 🥀💦 like, how we fumble the bag THIS hard?! 😭 Serparated got me feelin’ like I’m livin’ in a parallel universe where the dictionary got canceled on X 😪💀 Vro, we out here typin’ like we tryna speedrun a ban from English class 💨 Why this word lookin’ like it got lost in the Ohio backrooms?! 🫠💔 Blud, I’m screamin’ “SERPARATED” louder than a Fanum Tax collector at a GYATT convention 😤😤 This ain’t no Ohio W, this a global catastrophe, fam 🥀🥀 2025 hittin’ different but “serparated” hittin’ like a betrayal arc in a Discord server 💦💀 Vro, we serparated from the English language before we even got the GTA 6 trailer 2 drop, that’s diabolical 😭😭 I’m out here tryna rizz up the spellcheck but it’s ghostin’ me harder than a Situationship Rizzler 😪🚫 Serparated got me scrollin’ X for answers, but all I see is Skibidi memes and Ohio slander 💔💔 Blud, we in the ENDGAME of typos, no Ohio redemption arc in sight 😤🥀 aw naw, vro, this typo so wild it’s got me rethinkin’ my whole existence 🫠💦 Like, who let “serparated” cook?! 😭 Who greenlit this in the group chat?! 💀🥀🥀 I’m out here serparated from my braincells, movin’ like I got hit with a Fanum Tax on my IQ 😪😪 Vro, we spellin’ like we tryna summon the Ohio Backrooms Entity with every keystroke 💨💀 Serparated hittin’ harder than the GYATT nerf in 2025, no Ohio W’s, only Ohio L’s 🥀