### PR TITLE
Add max FPS setting to graphics UI

### DIFF
--- a/game/client-ui/src/main_menu/settings/graphics/main_frame.rs
+++ b/game/client-ui/src/main_menu/settings/graphics/main_frame.rs
@@ -142,6 +142,14 @@ fn render_settings(ui: &mut egui::Ui, pipe: &mut UiRenderPipe<UserData>) {
         ui.checkbox(&mut config_game.cl.render.use_ingame_aspect_ratio, "");
         ui.end_row();
 
+        ui.label("Max FPS (0 = unlimited)");
+        ui.add(
+            DragValue::new(&mut config_game.cl.refresh_rate)
+                .range(0..=10000)
+                .suffix(" fps"),
+        );
+        ui.end_row();
+
         if config_game.cl.render.use_ingame_aspect_ratio {
             let aspect_ratio = config_game.cl.render.ingame_aspect_ratio;
             let conf_values = ConfigRender::conf_values_structured();


### PR DESCRIPTION
The `refresh_rate` field already existed in `ConfigClient` but had no UI. 
This PR adds a DragValue widget to the graphics settings to allow users to set a max FPS limit (0 = unlimited).
<img width="719" height="500" alt="image" src="https://github.com/user-attachments/assets/b94dbf14-7815-4328-a061-1ee0a60e35ff" />
